### PR TITLE
Add optional path parameter for file creation and update version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A CLI tool for React and TypeScript developers to quickly generate components, t
 
 ## Need Contirbutors 📢📢📢
 
+## 🪲 Please create a issue if you want to contribute to this project. I will assign you a task and you can work on it.
+[Open Issues](https://github.com/carpediem23/ra-cli/issues)
+
 ## Installation
 
 ```bash
@@ -52,3 +55,15 @@ npx ra create --context --name ContextSample
 ```
 
 This will create a React context in `ContextSample.tsx` that includes a context component named `ContextSample` and a custom hook named `useContextSample` to use the context.
+
+### Specifying a Path
+
+You can specify where to create the files using the `--path` option:
+
+```bash
+npx ra create --component --name Button --path src/components
+```
+
+This will create `Button.tsx` in the `src/components` directory. If the directory doesn't exist, it will be created automatically.
+
+The path option works with all creation commands (component, type, interface, hook, context).

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A CLI tool for React and TypeScript developers to quickly generate components, t
 
 ## Need Contirbutors 📢📢📢
 
-## 🪲 Please create a issue if you want to contribute to this project. I will assign you a task and you can work on it.
-[Open Issues](https://github.com/carpediem23/ra-cli/issues)
+## 🪲 Please create a issue if you want to contribute to this project.
+[https://github.com/carpediem23/ra-cli/issues](https://github.com/carpediem23/ra-cli/issues)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carpediem23/ra-cli",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "CLI tool to generate React component templates",
   "homepage": "https://github.com/carpediem23/ra-cli#readme",
   "bugs": {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,9 +1,12 @@
 import fs from "fs";
 import path from "path";
-import { getTemplateContent } from "../utils/fileUtils";
+import {
+  getTemplateContent,
+  ensureDirectoryExistence,
+} from "../utils/fileUtils";
 
 export class Commands {
-  createComponent(name: string): void {
+  createComponent(name: string, targetPath?: string): void {
     try {
       const componentTemplate = getTemplateContent("component.template");
       const formattedContent = componentTemplate.replace(
@@ -11,7 +14,15 @@ export class Commands {
         name,
       );
       const rootDir = process.cwd();
-      const componentFilePath = path.join(rootDir, `${name}.tsx`);
+
+      let componentFilePath: string;
+      if (targetPath) {
+        const fullTargetPath = path.join(rootDir, targetPath);
+        ensureDirectoryExistence(fullTargetPath);
+        componentFilePath = path.join(fullTargetPath, `${name}.tsx`);
+      } else {
+        componentFilePath = path.join(rootDir, `${name}.tsx`);
+      }
 
       fs.writeFileSync(componentFilePath, formattedContent);
       console.info(`Component ${name} created successfully!`);
@@ -22,12 +33,20 @@ export class Commands {
     }
   }
 
-  createType(name: string): void {
+  createType(name: string, targetPath?: string): void {
     try {
       const typeTemplate = getTemplateContent("type.template");
       const formattedContent = typeTemplate.replace(/{{TypeName}}/g, name);
       const rootDir = process.cwd();
-      const typeFilePath = path.join(rootDir, `${name}.ts`);
+
+      let typeFilePath: string;
+      if (targetPath) {
+        const fullTargetPath = path.join(rootDir, targetPath);
+        ensureDirectoryExistence(fullTargetPath);
+        typeFilePath = path.join(fullTargetPath, `${name}.ts`);
+      } else {
+        typeFilePath = path.join(rootDir, `${name}.ts`);
+      }
 
       fs.writeFileSync(typeFilePath, formattedContent);
       console.info(`Type ${name} created successfully!`);
@@ -38,7 +57,7 @@ export class Commands {
     }
   }
 
-  createInterface(name: string): void {
+  createInterface(name: string, targetPath?: string): void {
     try {
       const interfaceTemplate = getTemplateContent("interface.template");
       const formattedContent = interfaceTemplate.replace(
@@ -46,7 +65,15 @@ export class Commands {
         name,
       );
       const rootDir = process.cwd();
-      const interfaceFilePath = path.join(rootDir, `${name}.ts`);
+
+      let interfaceFilePath: string;
+      if (targetPath) {
+        const fullTargetPath = path.join(rootDir, targetPath);
+        ensureDirectoryExistence(fullTargetPath);
+        interfaceFilePath = path.join(fullTargetPath, `${name}.ts`);
+      } else {
+        interfaceFilePath = path.join(rootDir, `${name}.ts`);
+      }
 
       fs.writeFileSync(interfaceFilePath, formattedContent);
       console.info(`Interface ${name} created successfully!`);
@@ -57,12 +84,20 @@ export class Commands {
     }
   }
 
-  createHook(name: string): void {
+  createHook(name: string, targetPath?: string): void {
     try {
       const hookTemplate = getTemplateContent("hook.template");
       const formattedContent = hookTemplate.replace(/{{HookName}}/g, name);
       const rootDir = process.cwd();
-      const hookFilePath = path.join(rootDir, `${name}.ts`);
+
+      let hookFilePath: string;
+      if (targetPath) {
+        const fullTargetPath = path.join(rootDir, targetPath);
+        ensureDirectoryExistence(fullTargetPath);
+        hookFilePath = path.join(fullTargetPath, `${name}.ts`);
+      } else {
+        hookFilePath = path.join(rootDir, `${name}.ts`);
+      }
 
       fs.writeFileSync(hookFilePath, formattedContent);
       console.info(`Hook ${name} created successfully!`);
@@ -73,7 +108,7 @@ export class Commands {
     }
   }
 
-  createContext(name: string): void {
+  createContext(name: string, targetPath?: string): void {
     try {
       const contextTemplate = getTemplateContent("context.template");
       const formattedContent = contextTemplate.replace(
@@ -81,7 +116,15 @@ export class Commands {
         name,
       );
       const rootDir = process.cwd();
-      const contextFilePath = path.join(rootDir, `${name}.tsx`);
+
+      let contextFilePath: string;
+      if (targetPath) {
+        const fullTargetPath = path.join(rootDir, targetPath);
+        ensureDirectoryExistence(fullTargetPath);
+        contextFilePath = path.join(fullTargetPath, `${name}.tsx`);
+      } else {
+        contextFilePath = path.join(rootDir, `${name}.tsx`);
+      }
 
       fs.writeFileSync(contextFilePath, formattedContent);
       console.info(`Context ${name} created successfully!`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { Command } from "commander";
 import { Commands } from "./commands/commands";
+import fs from "fs";
+import path from "path";
 
 class RACLI {
   private program: Command;
@@ -11,9 +13,21 @@ class RACLI {
     this.configureCommands();
   }
 
+  private getVersion(): string {
+    try {
+      const packageJsonPath = path.resolve(__dirname, "../package.json");
+      const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+      const packageJson = JSON.parse(packageJsonContent);
+      return packageJson.version || "1.0.0";
+    } catch (error) {
+      console.error("Error reading version from package.json:", error);
+      return "1.0.0";
+    }
+  }
+
   private configureCommands(): void {
-    this.program
-      .version("1.0.0")
+    const createCommand = this.program
+      .version(this.getVersion())
       .command("create")
       .description(
         "Create React components, types, interfaces, hooks or contexts",
@@ -42,6 +56,19 @@ class RACLI {
           );
         }
       });
+
+    createCommand.addHelpText(
+      "after",
+      `
+      Examples:
+        $ ra create --component --name Button
+        $ ra create --type --name TUserData
+        $ ra create --interface --name IUserProfile
+        $ ra create --hook --name useAuth
+        $ ra create --context --name Theme
+        $ ra create --component --name Header --path src/components
+      `,
+    );
 
     this.program.on("command:*", (operands) => {
       console.error(`Error: Unknown command '${operands[0]}'`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,18 +23,19 @@ class RACLI {
       .option("-i, --interface", "Create a TypeScript interface")
       .option("-h, --hook", "Create a React hook")
       .option("-x, --context", "Create a React context")
+      .option("-p, --path <path>", "Path to create the file (optional)")
       .requiredOption("-n, --name <name>", "Name of the item to create")
       .action((options) => {
         if (options.component) {
-          this.commands.createComponent(options.name);
+          this.commands.createComponent(options.name, options.path);
         } else if (options.type) {
-          this.commands.createType(options.name);
+          this.commands.createType(options.name, options.path);
         } else if (options.interface) {
-          this.commands.createInterface(options.name);
+          this.commands.createInterface(options.name, options.path);
         } else if (options.hook) {
-          this.commands.createHook(options.name);
+          this.commands.createHook(options.name, options.path);
         } else if (options.context) {
-          this.commands.createContext(options.name);
+          this.commands.createContext(options.name, options.path);
         } else {
           console.info(
             "Please specify what to create (--component, --type, --interface, --hook, or --context)",


### PR DESCRIPTION
Introduce an optional `--path` parameter for creating components, types, interfaces, hooks, and contexts in specified directories. Update the CLI version to 1.2.0 and enhance command help text with usage examples.